### PR TITLE
Honor _GTK_FRAME_EXTENTS when tiling GTK3 client‑side decorated windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,9 +11,10 @@
   pip cache files in the user's home directory.
 - Assorted documentation improvements.
 - Continued efforts to increase automated testing
-- Compensate for GTK3 client‑side decoration shadows by reading the
+- Honor GTK3 client‑side decoration shadows by reading the
   `_GTK_FRAME_EXTENTS` X11 property and adjusting window geometry so that
-  tiled windows’ **content** snaps flush to the monitor edge (closes #49).
+  the *content* area (rather than the drop shadow) snaps flush to the monitor
+  edge when tiling.
 
 
 0.4.0:

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,10 @@
   pip cache files in the user's home directory.
 - Assorted documentation improvements.
 - Continued efforts to increase automated testing
+- Compensate for GTK3 client‑side decoration shadows by reading the
+  `_GTK_FRAME_EXTENTS` X11 property and adjusting window geometry so that
+  tiled windows’ **content** snaps flush to the monitor edge (closes #49).
+
 
 0.4.0:
 - Port to Python 3.x and GTK 3.x

--- a/quicktile/wm.py
+++ b/quicktile/wm.py
@@ -450,11 +450,9 @@ class WindowManager:
         :param geometry_mask: Which aspects of the requested geometry to apply.
         """
 
-        # 1) Compute current window geometry relative to its monitor
         old_geom = Rectangle(*win.get_geometry()).to_relative(
             self.get_monitor(win)[1])
 
-        # 2) Build any overrides from geom (x, y, width, height)
         new_args = {}
         if geom:
             for attr in ('x', 'y', 'width', 'height'):
@@ -462,10 +460,10 @@ class WindowManager:
                                            attr.upper()):
                     new_args[attr] = getattr(geom, attr)
 
-        # 3) Apply overrides and go back to absolute screen coordinates
+        # Apply changes and return to absolute desktop coordinates
         new_geom = old_geom._replace(**new_args).from_relative(monitor)
 
-        # 4) Compensate for GTK3 client‑side decoration shadows
+        # Account for client-side decoration shadows (CSD)
         try:
             left, right, top, bottom = self._get_frame_extents(win)
         except Exception as err:  # pylint: disable=broad-except
@@ -481,7 +479,7 @@ class WindowManager:
                 height=new_geom.height + top + bottom
             )
 
-        # 5) Clip to usable region if we're just moving (no explicit geom)
+        # Ensure the window is fully within the monitor
         if bool(monitor) and not geom:
             clipped_geom = self.usable_region.clip_to_usable_region(new_geom)
         else:


### PR DESCRIPTION
### Summary

Ensure that GTK3 client‑side decorated apps (Evince, Nautilus, etc.) tile flush
to the screen edge by reading the `_GTK_FRAME_EXTENTS` X11 property and
adjusting the requested geometry so that the *content* area—rather than the
drop shadow—is anchored to the monitor border.

### Changes

- Add private helper `_get_frame_extents(win)` to fetch the four ints (L, R, T, B)
  from the `_GTK_FRAME_EXTENTS` property, returning (0,0,0,0) if missing/malformed.
- In `WindowManager.reposition()`, expand the new geometry by those extents and
  offset x/y so that the CSD shadow lies off‑screen and the visible client area
  snaps exactly to the edge.
- All existing behavior (no property, non‑GTK3 apps) falls back to zero‑margin.

### Testing

1. Under X11 (XFCE or any WM), open a GTK3 CSD application like Evince.
2. Tile it to the left or right half of the screen.
3. Confirm there is no gap between the document view and the screen edge.

_No version bump or FAQ update required — this is a minor internal tweak._
